### PR TITLE
A few ideas for the linting docs

### DIFF
--- a/docs/pages/docs/routing/navigation.mdx
+++ b/docs/pages/docs/routing/navigation.mdx
@@ -33,7 +33,7 @@ For example:
 
 ---
 
-Each strategy will provide you with corresponding [navigation APIs](#apis) that you'll typically provide in a central module to easily access them in components (e.g. `src/navigation.ts`). To ensure cnosistent usage in your app, you can consider [linting for usage of these APIs](/docs/workflows/linting#consistent-usage-of-navigation-apis).
+Each strategy will provide you with corresponding [navigation APIs](#apis) that you'll typically provide in a central module to easily access them in components (e.g. `src/navigation.ts`). To ensure consistent usage in your app, you can consider [linting for usage of these APIs](/docs/workflows/linting#consistent-usage-of-navigation-apis).
 
 ### Strategy 1: Shared pathnames [#shared-pathnames]
 

--- a/docs/pages/docs/routing/navigation.mdx
+++ b/docs/pages/docs/routing/navigation.mdx
@@ -13,11 +13,6 @@ import Details from 'components/Details';
 
 ## Strategies
 
-<Callout>
-  Use linting rules to enforce the usage of the different strategies. See the
-  [Linting](/docs/workflows/linting) guide for more information.
-</Callout>
-
 There are two strategies that you can use based on your needs.
 
 **Shared pathnames:** The simplest case is when your app uses the same pathnames, regardless of the locale.
@@ -38,7 +33,7 @@ For example:
 
 ---
 
-Each strategy will provide you with corresponding [navigation APIs](#apis) that you'll typically provide in a central module to easily access them in components (e.g. `src/navigation.ts`).
+Each strategy will provide you with corresponding [navigation APIs](#apis) that you'll typically provide in a central module to easily access them in components (e.g. `src/navigation.ts`). To ensure cnosistent usage in your app, you can consider [linting for usage of these APIs](/docs/workflows/linting#consistent-usage-of-navigation-apis).
 
 ### Strategy 1: Shared pathnames [#shared-pathnames]
 

--- a/docs/pages/docs/workflows/linting.mdx
+++ b/docs/pages/docs/workflows/linting.mdx
@@ -1,81 +1,29 @@
-import {Tab, Tabs} from 'nextra-theme-docs';
-
 # Linting
 
-To ensure the correct usage of `next-intl`, you can use linting to enforce certain rules.
+To ensure the correct usage of `next-intl`, you can use ESLint to enforce certain rules.
 
-These example rules apply if you are using [i18n routing](/docs/getting-started/app-router).
-You will need to adjust the rules to direct the user to the correct location where you are exporting the `next-intl` routing helpers, see [Navigation](/docs/routing/navigation) for more information.
+## Consistent usage of navigation APIs
 
-<Tabs items={['ESlint legacy config', 'ESlint flat config']}>
-<Tab>
+If you are using [i18n routing](/docs/getting-started/app-router), you might want to ensure that developers consistently use the [navigation APIs](/docs/routing/navigation) that you've configured in your project.
 
-```json filename="eslintrc.json"
-{
-  "rules": {
-    "no-restricted-imports": [
-      "error",
-      // Disallow the usage of the native Next.js `Link` component
+In this example, developers will be prompted to import from `@/navigation` when they try to import navigation APIs from Next.js.
+
+```javascript filename="eslint.config.js"
+// ...
+
+  rules: {
+    // Consistently import navigation APIs from `@/navigation`
+    'no-restricted-imports': [
+      'error',
       {
-        "name": "next/link",
-        "message": "Please use <location of re-exported functions> instead."
+        name: 'next/link',
+        message: 'Please import from `@/navigation` instead.'
       },
-      // Disallow the specific functions that `next-intl` re-exports
       {
-        "name": "next/navigation",
-        "importNames": [
-          "redirect",
-          "permanentRedirect",
-          "useRouter",
-          "usePathname"
-        ],
-        "message": "Please use <location of re-exported functions> instead."
-      },
-      // Disallow usage of the old router APIs
-      {
-        "name": "next/router",
-        "message": "Please use <location of re-exported functions> instead."
+        name: 'next/navigation',
+        importNames: ['redirect', 'permanentRedirect', 'useRouter', 'usePathname'],
+        message: 'Please import from `@/navigation` instead.'
       }
     ]
   }
-}
 ```
-
-</Tab>
-<Tab>
-
-```javascript filename="eslint.config.js"
-export default [
-  {
-    rules: {
-      'no-restricted-imports': [
-        'error',
-        // Disallow the usage of the native Next.js `Link` component
-        {
-          name: 'next/link',
-          message: 'Please use <location of re-exported functions> instead.'
-        },
-        // Disallow the specific functions that `next-intl` re-exports
-        {
-          name: 'next/navigation',
-          importNames: [
-            'redirect',
-            'permanentRedirect',
-            'useRouter',
-            'usePathname'
-          ],
-          message: 'Please use <location of re-exported functions> instead.'
-        },
-        // Disallow usage of the old router APIs
-        {
-          name: 'next/router',
-          message: 'Please use <location of re-exported functions> instead.'
-        }
-      ]
-    }
-  }
-];
-```
-
-</Tab>
-</Tabs>


### PR DESCRIPTION
Thanks a lot for your initiative to set up this page! Looks really cool already, here are a few changes I'd propose. Let me know what you think! :)



**Proposed changes:**
 - Use inline text link in navigation docs instead of callout to link to linting. Callouts make the docs pages unfortunately a bit noisy to read, I'm trying to reduce them to really critical info :)
 - Mention "ESLint" on linting page, to be able to find it via search
 - Separate section for consistent usage of navigation APIs (so we could potentially add further sections in the future)
 - Use a snippet that works for either flat or legacy ESLint config, so that we could use tabs in the future for other linters like Biome
 - Showcase example to import from `@/navigation` (that's what we're proposing on the navigation page)
 - Remove usage of `next/router` as it's typically not used in App Router setups